### PR TITLE
fix: update workflow assignments for reliability and tech-stack agnosticism

### DIFF
--- a/ai_instruction_modules/ai-workflow-assignments/create-project-structure.md
+++ b/ai_instruction_modules/ai-workflow-assignments/create-project-structure.md
@@ -15,9 +15,9 @@ Create the actual project structure and scaffolding for a new application based 
 
 ### Acceptance Criteria
 
-1. Solution structure created following established guidelines
+1. Solution/project structure created following the application plan's tech stack
 2. All required project files and directories established
-3. Initial configuration files created (global.json, Docker, etc.)
+3. Initial configuration files created (version pinning, Docker, etc.)
 4. Basic CI/CD pipeline structure established
 5. Documentation structure created (README, docs folder, etc.)
 6. Development environment properly configured and validated
@@ -35,22 +35,30 @@ It is important to the final quality of our product for everyone to perform thei
 
 ### Detailed Steps
 
-1. **Create Solution Structure**
-   1. Create .NET solution file with appropriate name
-   2. Set up global.json with specified .NET version
+> **Tech-stack selection:** Read the application plan (`plan_docs/`, `APP_PLAN.md`, or the
+> planning issue) to determine the target tech stack. The steps below use generic terms.
+> Adapt solution files, package managers, and project conventions to the actual stack
+> (e.g. `.sln`/`.csproj` for .NET, `pyproject.toml`/`uv` for Python, `package.json` for Node, etc.).
+
+1. **Create Solution / Project Structure**
+   1. Create the appropriate solution or workspace file for the chosen tech stack
+   2. Set up version pinning (e.g. `global.json` for .NET, `.python-version` for Python, `.nvmrc` for Node)
    3. Create project directories following established naming conventions
    4. Generate initial project files for each component
    5. Configure project references and dependencies
-   6. Configure projects settings and options 
-      a."Treat warnings as errors": true
-      b. "Create XML documentation files": true
+   6. Configure project-specific quality settings as appropriate for the tech stack (e.g. treat-warnings-as-errors, linting rules, type checking)
 
 2. **Establish Infrastructure Foundation**
    1. Create Dockerfile for each service/component
+      - **IMPORTANT:** When using `uv pip install -e .` or similar editable installs, ensure `COPY src/ ./src/` (or the equivalent source directory) appears **before** the install command. Copying only `pyproject.toml` first and then running the install will fail because the source tree is missing at install time.
    2. Create docker-compose.yml for local development
+      - **IMPORTANT:** Do NOT use `curl` in healthcheck commands — the base image may not have curl installed. Use Python's stdlib instead:
+        ```yaml
+        healthcheck:
+          test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health')"]
+        ```
    3. Set up configuration files (appsettings.json templates)
    4. Create environment variable templates
-   <!-- 5. Set up logging and monitoring configuration -->
 
 3. **Create Development Environment**
    1. Create scripts for environment setup
@@ -99,12 +107,14 @@ It is important to the final quality of our product for everyone to perform thei
 2. Verify build and configuration
 3. Obtain approval
 
-### Example Project Structure (dotnet)
+### Example Project Structures
 
-Use this project structure for all .NET projects unless otherwise specified by the stakeholder. Adjust the structure as needed based on the specific requirements of the application and the guidelines provided in the application plan and template documents.
+Adapt the structure to the tech stack specified in the application plan. Below are reference examples — adjust as needed.
 
-```
-/ 
+#### .NET
+
+```text
+/
    SolutionName/
       ProjectName.API/
          Controllers/
@@ -114,14 +124,46 @@ Use this project structure for all .NET projects unless otherwise specified by t
       ProjectName.Application/
          Interfaces/
       ...
-      ProjectName.XYZ/
       Tests/
          TestProjectName/
             TestClasses.cs
             TestProjectName.csproj
-         ...
-         Tests.slnx
       SolutionName.slnx
+```
+
+#### Python (uv)
+
+```text
+/
+   src/
+      package_name/
+         __init__.py
+         main.py
+         api/
+         models/
+         services/
+   tests/
+      test_main.py
+   pyproject.toml
+   Dockerfile
+   docker-compose.yml
+```
+
+#### Node.js / TypeScript
+
+```text
+/
+   src/
+      index.ts
+      routes/
+      models/
+      services/
+   tests/
+      index.test.ts
+   package.json
+   tsconfig.json
+   Dockerfile
+   docker-compose.yml
 ```
 
 ### Completion

--- a/ai_instruction_modules/ai-workflow-assignments/init-existing-repository.md
+++ b/ai_instruction_modules/ai-workflow-assignments/init-existing-repository.md
@@ -45,11 +45,11 @@ The script will test all required permissions and can automatically attempt to f
 
 ### Acceptance Criteria
 
-0. PR and new branch created
-1. Git Project created for issue tracking
+0. PR and new branch created (must be first — all other work commits here)
+1. GitHub Project created for issue tracking (see manual step in Detailed Steps)
 2. Git Project linked to repository
 3. Project columns created: Not Started, In Progress, In Review, Done
-4. Labels imported for issue management
+4. Labels imported from `.github/.labels.json` for issue management
 5. Filenames changed to match project name
 
 ### Assignment
@@ -62,7 +62,29 @@ It is important to the final quality of our product for everyone to perform thei
 
 ### Detailed Steps
 
-1. **Create GitHub Project for Issue Tracking**
+1. **Create PR and New Branch**
+   - **This must be done first** — all subsequent steps commit to this branch.
+   - Create a new branch named after the invoking dynamic workflow assignment which called this workflow assignment, with the prefix `dynamic-workflow-`.
+   - For example, if the dynamic workflow assignment is `project-setup`, the branch should be named `dynamic-workflow-project-setup`.
+   - Create a PR from this branch to `main`. The PR will be left open until all subsequent assignments are complete and approved.
+   - If branch creation or PR creation fails, stop and report the error immediately — do not proceed with other steps.
+
+2. **Create GitHub Project for Issue Tracking**
+
+   > **IMPORTANT — Manual Step Required**
+   >
+   > Creating the GitHub Project **cannot** be done reliably during automated
+   > orchestration because the devcontainer image may not be built yet when
+   > this assignment runs. Instead, run the script **manually** after the first
+   > orchestrator run completes and images are available:
+   >
+   > ```powershell
+   > ./scripts/create-project.ps1 -Owner <org> -Repo <repo-name>
+   > ```
+   >
+   > The script creates a Board-template project named after the repo, links
+   > it, and prints the project URL. Requires `gh` CLI with `project` scope.
+
    - Create a new GitHub Project for issue tracking
    - Name the project the same as the repository
    - Set the project to `Board` template
@@ -74,20 +96,14 @@ It is important to the final quality of our product for everyone to perform thei
      - In Review
      - Done
 
-2. **Import Labels**
-   - Import the labels from the `.labels.json` file in the root of the repository
-   - Use the `import-labels.ps1` script to import the labels
+3. **Import Labels**
+   - Import the labels from the `.github/.labels.json` file (note: inside the `.github/` directory, not the repo root)
+   - This file is the single source of truth for the repository label set
+   - Use the `scripts/import-labels.ps1` script to import the labels
 
-3.  **Rename Workspace and Devcontainer Files**
+4. **Rename Workspace and Devcontainer Files**
    - Inside the `.devcontainer/devcontainer.json` file rename the `name` property to use the repository name as the prefix, preserving the "devcontainer" suffix. Template: `<repo-name>-devcontainer`
    - Rename the `ai-new-app-template.code-workspace` file to use the repository name as the prefix, preserving the ".code-workspace" extension. Template: `<repo-name>.code-workspace`
-
-4. **Create PR and New Branch**
-- Create a new branch named after the invoking dynamic workflow assignment which called this workflow assignment, with the prefix `dynamic-workflow-`.
-- For example, if the dynamic workflow assignment is `project-setup`, the branch should be named `dynamic-workflow-project-setup`.
-
-- Changes will most likely not be made until subsequent workflow assignments invoked after this one, so it will be left open until all subsequent assignments are complete and approved.
-- Later workflow assignments will commit and push changes to this branch.
 
 5. **Final Steps**
    - Nothing to do here, just proceed to the completion section below. 


### PR DESCRIPTION
Companion PR to intel-agency/ai-new-workflow-app-template#6

## init-existing-repository.md
- PR/branch creation moved to step 1 — ensures branch exists before other work [Issue 3]
- .labels.json path corrected from repo root to .github/.labels.json
- Added manual project creation instructions with create-project.ps1 [Issue 4]
- Updated acceptance criteria for clarity

## create-project-structure.md
- Made tech-stack-agnostic: agents now read stack from app plan instead of assuming .NET [Issue 20]
- Added Dockerfile COPY ordering guardrail — source must be copied before editable install [Issue 10]
- Added healthcheck guardrail — use Python stdlib, not curl [Issue 11]
- Added Python and Node.js example project structures alongside .NET
- Updated acceptance criteria wording